### PR TITLE
Fail Manifest Read when File Doesn't Exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.4.3] 2018-05-11
+
+### Fixed
+- Fail manifest read if file doesn't exist instead of when it exists
+
 ## [0.4.2] 2018-05-05
 
 ### Fixed

--- a/Sources/Manifest/Manifest.swift
+++ b/Sources/Manifest/Manifest.swift
@@ -66,7 +66,7 @@ public final class Manifest: Codable {
         guard let resolvedURL = URL(string: self.path!) else {
             throw ManifestError(identifier: "badURL", reason: "Unable to create URL for package manifest file.")
         }
-        if !fileManager.fileExists(atPath: self.path!) {
+        if fileManager.fileExists(atPath: self.path!) {
             throw ManifestError(identifier: "badManifestPath", reason: "Bad path to package manifest. Make sure you are in the project root.")
         }
         


### PR DESCRIPTION
Fail manifest read if file doesn't exist instead of when it exists.